### PR TITLE
fix: MediathekView startup in startapp.sh

### DIFF
--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -1,6 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env sh
+
 export HOME=/config
 
-/bin/sh -c MediathekView
-
-sleep infinity
+exec /usr/local/bin/MediathekView


### PR DESCRIPTION
This will ensure the container fails if the startup of MediathekView failed. In the current setup the container will stay u because sleep is used as last call.