### PR TITLE
Properly set Java Home Directory

### DIFF
--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -2,4 +2,11 @@
 
 export HOME=/config
 
-exec /usr/local/bin/MediathekView
+exec java \
+  -XX:+UseShenandoahGC \
+  -XX:ShenandoahGCHeuristics=compact \
+  -XX:+UseStringDeduplication \
+  -XX:MaxRAMPercentage=75.0 \
+  --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED \
+  -Duser.home=/config \
+  -jar /opt/MediathekView/MediathekView.jar


### PR DESCRIPTION
This pull request updates the startapp.sh script to explicitly set the user.home system property for Java, ensuring that MediathekView uses a writable config directory (/config) instead of falling back to /dev/null.